### PR TITLE
Bug fixes when switching the player

### DIFF
--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -18,7 +18,7 @@ const ListItem = ({ item, isChild }) => {
     item.items && item.items.length > 0 && childCanvases.length === 0 ? (
       <List items={item.items} isChild={true} />
     ) : null;
-  const liRef = useRef(null)
+  const liRef = useRef(null);
 
   const handleClick = (e) => {
     e.stopPropagation();
@@ -45,12 +45,16 @@ const ListItem = ({ item, isChild }) => {
 
   useEffect(() => {
     if (currentNavItem == item) {
-      liRef.current.className += " active";
+      liRef.current.className += ' active';
     }
   }, [currentNavItem]);
 
   return (
-    <li data-testid="list-item" ref={liRef} className="irmp--structured-nav__list-item">
+    <li
+      data-testid="list-item"
+      ref={liRef}
+      className="irmp--structured-nav__list-item"
+    >
       {renderListItem()}
       {subMenu}
     </li>

--- a/src/components/MediaPlayer/MediaPlayer.js
+++ b/src/components/MediaPlayer/MediaPlayer.js
@@ -50,14 +50,12 @@ const MediaPlayer = () => {
     error ? setReady(false) : setReady(true);
   };
 
+  // Switch player when navigating across canvases
   const switchPlayer = () => {
     initCanvas(canvasIndex);
-    if (isPlaying) {
-      player.play();
-    }
-    player.currentTime(startTime);
   };
 
+  // Load next canvas in the list when current media ends
   const handleEnded = () => {
     initCanvas(canvasIndex + 1);
   };

--- a/src/components/MediaPlayer/VideoJSPlayer.js
+++ b/src/components/MediaPlayer/VideoJSPlayer.js
@@ -17,7 +17,7 @@ import {
   useManifestState,
   useManifestDispatch,
 } from '../../context/manifest-context';
-import { hasNextSection } from '@Services/iiif-parser';
+import { hasNextSection, getNextItem } from '@Services/iiif-parser';
 
 function VideoJSPlayer({
   isVideo,
@@ -147,6 +147,13 @@ function VideoJSPlayer({
   const handleEnded = () => {
     if (hasNextSection({ canvasIndex, manifest })) {
       manifestDispatch({ canvasIndex: canvasIndex + 1, type: 'switchCanvas' });
+      // Reset startTime to zero
+      playerDispatch({ startTime: 0, type: 'setTimeFragment' });
+      // Update the current nav item to next item
+      manifestDispatch({
+        item: getNextItem({ canvasIndex, manifest }),
+        type: 'switchItem',
+      });
 
       handleIsEnded();
 

--- a/src/json/multiple-sources.js
+++ b/src/json/multiple-sources.js
@@ -297,12 +297,24 @@ export default {
           type: 'Range',
           id:
             'https://dlib.indiana.edu/iiif-av/iiif-player-samples/volleybal-for-boys/manifest/range/2',
-          label: 'Volleyball for Boys',
+          label: {
+            en: ['Volleyball for Boys'],
+          },
           items: [
             {
-              type: 'Canvas',
+              type: 'Range',
               id:
-                'https://dlib.indiana.edu/iiif-av/iiif-player-samples/volleybal-for-boys/manifest/canvas/2#t=0,',
+                'https://dlib.indiana.edu/iiif-av/iiif-player-samples/volleybal-for-boys/manifest/range/2-1',
+              label: {
+                en: ['Volleyball for Boys'],
+              },
+              items: [
+                {
+                  type: 'Canvas',
+                  id:
+                    'https://dlib.indiana.edu/iiif-av/iiif-player-samples/volleybal-for-boys/manifest/canvas/2#t=0,',
+                },
+              ],
             },
           ],
         },

--- a/src/services/iiif-parser.js
+++ b/src/services/iiif-parser.js
@@ -204,16 +204,19 @@ export function hasNextSection({ canvasIndex, manifest }) {
 }
 
 /**
- * Get duration of the selected canvas
- * @param {Object} manifest
- * @param {Number} canvasIndex - current canvas index
+ * Retrieve the next item in the structure to be played when advancing from
+ * canvas to next when media ends playing
+ * @param {Object} obj
+ * @param {Number} obj.canvasIndex index of the current canvas in manifets
+ * @param {Object} obj.manifest
+ * @return {Object} next item in the structure
  */
-export function getDuration(manifest, canvasIndex) {
-  const canvas = parseManifest(manifest).getSequences()[0].getCanvases()[
-    canvasIndex
-  ];
-  if (canvas) {
-    return canvas.getDuration();
+export function getNextItem({ canvasIndex, manifest }) {
+  if (hasNextSection({ canvasIndex, manifest }) && manifest.structures) {
+    const nextSection = manifest.structures[0].items[canvasIndex + 1];
+    if (nextSection.items) {
+      return nextSection.items[0];
+    }
+    return nextSection;
   }
-  return 0;
 }


### PR DESCRIPTION
This PR includes;
1. Bug fix for when switching audio -> video player with play() event
2. Marking the current nav item when advancing from canvas to next when the current media ends playing